### PR TITLE
bump goveralls and golangci

### DIFF
--- a/build.go/Dockerfile
+++ b/build.go/Dockerfile
@@ -5,8 +5,8 @@ ENV \
     CGO_ENABLED=0 \
     GOOS=linux \
     GOARCH=amd64 \
-    GOVERALLS=0.0.4 \
-    GOLANGCI=1.21.0 \
+    GOVERALLS=0.0.5 \
+    GOLANGCI=1.23.6 \
     STATIK=0.1.6
 
 RUN \


### PR DESCRIPTION
golangci brings new linters.

Changes for goveralls [by link](https://github.com/mattn/goveralls/compare/v0.0.4...v0.0.5).