### PR TITLE
Add "exec" portion before su-exec to replace the shell process of "init.sh"

### DIFF
--- a/base.alpine/files/init.sh
+++ b/base.alpine/files/init.sh
@@ -33,7 +33,7 @@ fi
 
 echo "execute \"$@\""
 if [[ ${uid} -eq 0 ]]; then
-   su-exec app $@
+   exec su-exec app $@
 else
    exec $@
 fi


### PR DESCRIPTION
Hi @umputun,

I found that your image uses "dumb-init" and "dumb-init" had following piece of documentation:

>     CMD ["bash", "-c", "do-some-pre-start-thing && exec my-server"]
> The exec portion of the bash command is important because it replaces the bash process with your server, so that the shell only exists momentarily at start.

I suppose that is why you call `exec $@` in _init.sh_ when it runs as "app" user: to replace the bash script with the command passed.

Also I noticed that su-exec doesn't do this replacement. I run as _root_ and as _app_ and get different result:

    $ docker run --user app --rm docker.pkg.github.com/umputun/baseimage/app:v1.5.0 ps -fA
    execute "ps -fA"
    PID   USER     TIME  COMMAND
        1 app       0:00 {init.sh} /sbin/dinit /bin/sh /init.sh ps -fA
        6 app       0:00 ps -fA
    $ docker run --rm docker.pkg.github.com/umputun/baseimage/app:v1.5.0 ps -fA
    init container
    set timezone America/Chicago (Wed Jul 29 14:14:46 CDT 2020)
    custom APP_UID not defined, using default uid=1001
    execute "ps -fA"
    PID   USER     TIME  COMMAND
        1 root      0:00 {init.sh} /sbin/dinit /bin/sh /init.sh ps -fA
        6 root      0:00 /bin/sh /init.sh ps -fA
       11 app       0:00 ps -fA

It might be not a big deal but a little bit of inconsistency.
With my fix it works this way:

    $ docker run --user app --rm umputun ps -fA
    execute "ps -fA"
    PID   USER     TIME  COMMAND
        1 app       0:00 {init.sh} /sbin/dinit /bin/sh /init.sh ps -fA
        7 app       0:00 ps -fA
    $ docker run --rm umputun ps -fA
    init container
    set timezone America/Chicago (Wed Jul 29 14:17:38 CDT 2020)
    custom APP_UID not defined, using default uid=1001
    execute "ps -fA"
    PID   USER     TIME  COMMAND
        1 root      0:00 {init.sh} /sbin/dinit /bin/sh /init.sh ps -fA
        8 app       0:00 ps -fA