### PR TITLE
Set TIME_ZONE for images in Makefile

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: build base.app image
       run: |
-        docker build --rm -f base.alpine/Dockerfile -t base.app:latest base.alpine
+        docker build --rm --build-arg TIME_ZONE=America/Chicago -f base.alpine/Dockerfile -t base.app:latest base.alpine
 
     - name: deploy base.app image
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -30,7 +30,7 @@ jobs:
 
     - name: build build.go image
       run: |
-        docker build --rm -f build.go/Dockerfile -t build.go:latest build.go
+        docker build --rm --build-arg TIME_ZONE=America/Chicago -f build.go/Dockerfile -t build.go:latest build.go
 
     - name: deploy build.go image
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+export TIME_ZONE := America/Chicago
+
 all: build_app build_go
 
 build_app:
-	docker build --pull -t umputun/baseimage:app-latest base.alpine -f base.alpine/Dockerfile
+	docker build --pull --build-arg TIME_ZONE=${TIME_ZONE} -t umputun/baseimage:app-latest base.alpine -f base.alpine/Dockerfile
 
 build_go:
-	docker build --pull -t umputun/baseimage:buildgo-latest build.go -f build.go/Dockerfile
+	docker build --pull --build-arg TIME_ZONE=${TIME_ZONE} -t umputun/baseimage:buildgo-latest build.go -f build.go/Dockerfile
 
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Two images included:
 1. go build image - `umputun/baseimage:buildgo-latest`. For build stage, includes go compiler and linters. Alpine based.
 2. base application image `umputun/baseimage:app-latest`
 
+Images TZ can be customized in Makefile.
+
+```Makefile
+export TIME_ZONE := America/Chicago
+```
+
 ## Go Build Image
 
 Image `umputun/baseimage:buildgo-latest` intends to be used in multi-stage `Dockefile` to build go applications and services.
@@ -18,7 +24,6 @@ Image `umputun/baseimage:buildgo-latest` intends to be used in multi-stage `Dock
 * Add useful packages for building and testing - [testify](https://github.com/stretchr/testify), [mockery](https://github.com/vektra/mockery) and [go-bindata](https://github.com/jteeuwen/go-bindata)
 * With [goveralls](https://github.com/mattn/goveralls) for easy integration with coverage services and provided `coverage.sh` script to report coverage.
 * `git-rev.sh` script to make git-based version without full `.git` copied (works without `.git/objects`)
-
 
 ## Base Application Image
 
@@ -36,8 +41,8 @@ It adds a few things to the regular [alpine image](https://hub.docker.com/_/alpi
 
 The container can be customized in runtime by setting environment from docker's command line or as a part of `docker-compose.yml`
 
-- `TIME_ZONE` - set container's TZ, default "America/Chicago"
-- `APP_UID` - UID of internal `app` user, default 1001
+* `TIME_ZONE` - set container's TZ, default "America/Chicago"
+* `APP_UID` - UID of internal `app` user, default 1001
 
 ## Example of multi-stage Dockerfile with baseimage:buildgo and baseimage:app
 
@@ -69,4 +74,3 @@ CMD ["/srv/app", "param1", "param2"]
 It will make a container running "/srv/app" (with passed params) under 'app' user.
 
 To customize both TIME_ZONE and UID - `docker run -e TIME_ZONE=America/New_York -e APP_UID=2000 <image>`
- 

--- a/base.alpine/Dockerfile
+++ b/base.alpine/Dockerfile
@@ -2,9 +2,11 @@ FROM alpine:3.13
 
 LABEL maintainer="Umputun <umputun@gmail.com>"
 
+ARG TIME_ZONE
+
 ENV \
     TERM=xterm-color           \
-    TIME_ZONE=America/Chicago  \
+    TIME_ZONE=${TIME_ZONE}     \
     APP_USER=app               \
     APP_UID=1001               \
     DOCKER_GID=999         

--- a/build.go/Dockerfile
+++ b/build.go/Dockerfile
@@ -1,8 +1,10 @@
 FROM golang:1.15-alpine
 LABEL maintainer="Umputun <umputun@gmail.com>"
 
+ARG TIME_ZONE
+
 ENV \
-    TIME_ZONE=America/Chicago \
+    TIME_ZONE=${TIME_ZONE} \
     CGO_ENABLED=0 \
     GOOS=linux \
     GOARCH=amd64 \


### PR DESCRIPTION
I tested this with my and Chicago time zone.
Run `make` and then `docker run --rm -i umputun/baseimage:buildgo-latest date` or `docker run --rm -i umputun/baseimage:app-latest date`. Command `date` will show right time for both images.
Minimum changes for users.