### PR TITLE
Possible typo in ghcr.io/umputun/baseimage/app tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Image `umputun/baseimage:buildgo-latest` and `ghcr.io/umputun/baseimage/buildgo:
 
 ## Base Application Image
 
-Image `umputun/baseimage:app-latest` and `ghcr.io/umputun/baseimage/app:lastest` designed as a lightweight, ready-to-use base for various services. It adds a few things to the regular [alpine image](https://hub.docker.com/_/alpine/).
+Image `umputun/baseimage:app-latest` and `ghcr.io/umputun/baseimage/app:latest` designed as a lightweight, ready-to-use base for various services. It adds a few things to the regular [alpine image](https://hub.docker.com/_/alpine/).
 
 * `ENTRYPOINT /init.sh` runs `CMD` via [dumb-init](https://github.com/Yelp/dumb-init/)
 * Container command runs under `app` user with uid `$APP_UID` (default 1001) 

--- a/base.scratch/Dockerfile
+++ b/base.scratch/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/umputun/baseimage/app:lastest as prep
+FROM ghcr.io/umputun/baseimage/app:latest as prep
 
 LABEL maintainer="Umputun <umputun@gmail.com>"
 


### PR DESCRIPTION
Hi,

I've noticed a possible typo in `base.scratch` Dockerfile: there is a reference to the `lastest` tag instead of `latest`.