### PR TITLE
Fix for Dockerfile smell DL3020

### DIFF
--- a/build.go/Dockerfile
+++ b/build.go/Dockerfile
@@ -28,8 +28,8 @@ RUN go install github.com/mattn/goveralls@v${GOVERALLS} && which goveralls
 RUN go install github.com/rakyll/statik@v${STATIK} && which statik
 RUN go install github.com/goreleaser/goreleaser@v${GORELEASER} &&  goreleaser -v
 
-ADD coverage.sh /script/coverage.sh
-ADD git-rev.sh /script/git-rev.sh
-ADD version.sh /script/version.sh
+COPY coverage.sh /script/coverage.sh
+COPY git-rev.sh /script/git-rev.sh
+COPY version.sh /script/version.sh
 
 RUN chmod +x /script/coverage.sh /script/git-rev.sh /script/version.sh


### PR DESCRIPTION
Hi!
The Dockerfile placed at "build.go/Dockerfile" contains the best practice violation [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3020 occurs if ADD is used to copy files and directories that do not require tar self-extraction. In such cases, it is recommended to use the COPY instruction.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the ADD instruction is replaced by an equivalent COPY instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance