### PR TITLE
Change GID of app group when changing UID of app user

### DIFF
--- a/base.alpine/files/init.sh
+++ b/base.alpine/files/init.sh
@@ -14,6 +14,7 @@ if [[ ${uid} -eq 0 ]]; then
     if [[ "${APP_UID}" -ne "1001" ]]; then
         echo "set custom APP_UID=${APP_UID}"
         sed -i "s/:1001:1001:/:${APP_UID}:${APP_UID}:/g" /etc/passwd
+        sed -i "s/:1001:/:${APP_UID}:/g" /etc/group
     else
         echo "custom APP_UID not defined, using default uid=1001"
     fi


### PR DESCRIPTION
Currently changing UID of the `app` user makes the  `app` group orphaned. Also `app` user becomes a member of an unknown group:

```
# docker container run -it --rm --env APP_UID=1000 umputun/baseimage:app-v1.14.0 sh
init container
set timezone America/Chicago (Tue Dec  3 04:30:02 CST 2024)
set custom APP_UID=1000
execute sh

/ $ id
uid=1000(app) gid=1000 groups=999(docker),1000
/ $ groups
1000groups: unknown ID 1000
 docker
```

and we have strange file ownership in `/home/app`:

```
/ $ touch /home/app/test
/ $ ls -l /home/app/test
-rw-r--r--    1 app      app              0 Dec  3 04:36 /home/app/test
/ $ ls -n /home/app/test
-rw-r--r--    1 1000     1001             0 Dec  3 04:36 /home/app/test
```