### PR TITLE
Drop dead code

### DIFF
--- a/base.alpine/Dockerfile
+++ b/base.alpine/Dockerfile
@@ -21,8 +21,7 @@ RUN \
     chmod +x /usr/bin/nop.sh /usr/bin/app.sh /init.sh /init-root.sh && \
     apk add --no-cache --update su-exec tzdata curl ca-certificates shared-mime-info dumb-init && \
     ln -s /sbin/su-exec /usr/local/bin/gosu && \
-    mkdir -p /home/$APP_USER && \
-    adduser -s /bin/sh -D -u $APP_UID $APP_USER && chown -R $APP_USER:$APP_USER /home/$APP_USER && \
+    adduser -s /bin/sh -D -u $APP_UID $APP_USER && \
     delgroup ping && addgroup -g 998 ping && \
     addgroup -g ${DOCKER_GID} docker && addgroup ${APP_USER} docker && \
     mkdir -p /srv && chown -R $APP_USER:$APP_USER /srv && \


### PR DESCRIPTION
There is no need to create home directory for `app` user manually. `adduser` command creates it and sets correct ownership automatically.

I also have a question. Why does `app` user need home directory and login shell at all? I mean why not create user by e.g. this command (`-H` means "don't create home directory"):
```
adduser -s /sbin/nologin -H -D -u 1001 app
```