### PR TITLE
Add DOCKER_GID runtime customization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ make build_scratch_multi
 
 - `base.alpine/` - Alpine runtime image
   - `Dockerfile` - image definition
-  - `files/init.sh` - entrypoint script, handles timezone and UID setup, drops to app user
+  - `files/init.sh` - entrypoint script, handles timezone, UID, and docker GID setup, drops to app user
   - `files/init-root.sh` - alternative entrypoint for root execution
 - `base.scratch/` - Scratch runtime image (builds /nop wait program from C)
 - `build.go/` - Go build image

--- a/README.md
+++ b/README.md
@@ -37,12 +37,24 @@ The container can be customized in runtime by setting environment from docker's 
 
 - `TIME_ZONE` - set container's TZ, default "America/Chicago". For scratch-based `TZ` should be used instead
 - `APP_UID` - UID of internal `app` user, default 1001
+- `DOCKER_GID` - GID of the docker group, default 999. Useful when mounting docker socket with a different GID on the host
 
 ### Working with Docker from inside container
 
 The `app` user is a member of the `docker` group. That allows it to interact with the Docker socket (`/var/run/docker.sock`) when it is explicitly mounted into the container. This is particularly useful for advanced use cases that require such functionality, such as monitoring other containers or accessing Docker APIs.
 
 Under standard usage, the Docker socket is not mounted into the container. In such cases, the docker group membership does not grant the app user any elevated privileges. The container remains secure and operates with an unprivileged user.
+
+When the host's docker group has a different GID than the container's default (999), set `DOCKER_GID` to match the host's GID:
+
+```bash
+# find your host docker GID
+stat -c %g /var/run/docker.sock  # Linux
+stat -f %g /var/run/docker.sock  # macOS
+
+# run with matching GID
+docker run -e DOCKER_GID=998 -v /var/run/docker.sock:/var/run/docker.sock <image>
+```
 
 #### Security Implications
 


### PR DESCRIPTION
**Problem**

When mounting the docker socket with a different GID on the host (e.g., 123, 998), the container's default docker group (GID 999) doesn't match, causing socket access failures. The `--group-add` docker flag doesn't help because `su-exec` drops supplementary groups.

**Solution**

Add `DOCKER_GID` environment variable handling to `init.sh`, similar to existing `APP_UID` handling:

- Check if `DOCKER_GID` differs from default 999
- If another group already uses that GID, add app user to that existing group
- Otherwise, recreate docker group with requested GID
- Includes error handling for group operations

**Usage**

```bash
# find host docker GID
stat -c %g /var/run/docker.sock  # Linux

# run with matching GID
docker run -e DOCKER_GID=998 -v /var/run/docker.sock:/var/run/docker.sock <image>
```

*Related to https://github.com/umputun/updater/pull/48*