### PR TITLE
Publish images under the repository owner and restrict workflow permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: build
 
 on:
   push:
-    branches:
-    tags:
+    branches: ["**"]
+    tags: ["**"]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
@@ -19,6 +19,9 @@ on:
       - 'Makefile'
       - '.github/dependabot.yml'
       - '.github/FUNDING.yml'
+
+permissions:
+  contents: read
 
 env:
   GHCR_OWNER: ${{ github.repository_owner }}
@@ -128,6 +131,9 @@ jobs:
 
   merge:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -182,21 +188,23 @@ jobs:
         run: |
           ref="${GITHUB_REF##*/}"
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            echo "ghcr_tags=-t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:${ref} -t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:latest" >> $GITHUB_OUTPUT
-            echo "dockerhub_tags=-t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-${ref} -t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-latest" >> $GITHUB_OUTPUT
+            echo "ghcr_tags=-t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:${ref} -t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:latest" >> "$GITHUB_OUTPUT"
+            echo "dockerhub_tags=-t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-${ref} -t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-latest" >> "$GITHUB_OUTPUT"
           else
-            echo "ghcr_tags=-t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:${ref}" >> $GITHUB_OUTPUT
-            echo "dockerhub_tags=-t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-${ref}" >> $GITHUB_OUTPUT
+            echo "ghcr_tags=-t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:${ref}" >> "$GITHUB_OUTPUT"
+            echo "dockerhub_tags=-t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-${ref}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: create ghcr manifest and push
         working-directory: /tmp/digests/ghcr
         run: |
+          # shellcheck disable=SC2046,SC2086 # both expansions have to split into separate arguments
           docker buildx imagetools create ${{ steps.tags.outputs.ghcr_tags }} \
             $(printf "ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}@sha256:%s " *)
 
       - name: create dockerhub manifest and push
         working-directory: /tmp/digests/dockerhub
         run: |
+          # shellcheck disable=SC2046,SC2086 # both expansions have to split into separate arguments
           docker buildx imagetools create ${{ steps.tags.outputs.dockerhub_tags }} \
             $(printf "docker.io/${DOCKERHUB_OWNER}/baseimage@sha256:%s " *)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,10 @@ on:
       - '.github/dependabot.yml'
       - '.github/FUNDING.yml'
 
+env:
+  GHCR_OWNER: ${{ github.repository_owner }}
+  DOCKERHUB_OWNER: ${{ vars.DOCKERHUB_OWNER || github.repository_owner }}
+
 jobs:
   build:
     strategy:
@@ -67,14 +71,14 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ env.GHCR_OWNER }}
           password: ${{ secrets.GITHUBPKG }}
 
       - name: login to dockerhub
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
         uses: docker/login-action@v4
         with:
-          username: ${{ github.actor }}
+          username: ${{ env.DOCKERHUB_OWNER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: build and push to ghcr.io
@@ -85,7 +89,7 @@ jobs:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.dockerfile }}
           platforms: ${{ matrix.platform.os }}
-          outputs: type=image,name=ghcr.io/${{ github.actor }}/baseimage/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/${{ env.GHCR_OWNER }}/baseimage/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: build and push to dockerhub
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
@@ -95,7 +99,7 @@ jobs:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.dockerfile }}
           platforms: ${{ matrix.platform.os }}
-          outputs: type=image,name=docker.io/${{ github.actor }}/baseimage,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=docker.io/${{ env.DOCKERHUB_OWNER }}/baseimage,push-by-digest=true,name-canonical=true,push=true
 
       - name: export digests
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
@@ -164,13 +168,13 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ env.GHCR_OWNER }}
           password: ${{ secrets.GITHUBPKG }}
 
       - name: login to dockerhub
         uses: docker/login-action@v4
         with:
-          username: ${{ github.actor }}
+          username: ${{ env.DOCKERHUB_OWNER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: set docker tags
@@ -178,21 +182,21 @@ jobs:
         run: |
           ref="${GITHUB_REF##*/}"
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            echo "ghcr_tags=-t ghcr.io/${{ github.actor }}/baseimage/${{ matrix.image }}:${ref} -t ghcr.io/${{ github.actor }}/baseimage/${{ matrix.image }}:latest" >> $GITHUB_OUTPUT
-            echo "dockerhub_tags=-t ${{ github.actor }}/baseimage:${{ matrix.image }}-${ref} -t ${{ github.actor }}/baseimage:${{ matrix.image }}-latest" >> $GITHUB_OUTPUT
+            echo "ghcr_tags=-t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:${ref} -t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:latest" >> $GITHUB_OUTPUT
+            echo "dockerhub_tags=-t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-${ref} -t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-latest" >> $GITHUB_OUTPUT
           else
-            echo "ghcr_tags=-t ghcr.io/${{ github.actor }}/baseimage/${{ matrix.image }}:${ref}" >> $GITHUB_OUTPUT
-            echo "dockerhub_tags=-t ${{ github.actor }}/baseimage:${{ matrix.image }}-${ref}" >> $GITHUB_OUTPUT
+            echo "ghcr_tags=-t ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}:${ref}" >> $GITHUB_OUTPUT
+            echo "dockerhub_tags=-t ${DOCKERHUB_OWNER}/baseimage:${{ matrix.image }}-${ref}" >> $GITHUB_OUTPUT
           fi
 
       - name: create ghcr manifest and push
         working-directory: /tmp/digests/ghcr
         run: |
           docker buildx imagetools create ${{ steps.tags.outputs.ghcr_tags }} \
-            $(printf 'ghcr.io/${{ github.actor }}/baseimage/${{ matrix.image }}@sha256:%s ' *)
+            $(printf "ghcr.io/${GHCR_OWNER}/baseimage/${{ matrix.image }}@sha256:%s " *)
 
       - name: create dockerhub manifest and push
         working-directory: /tmp/digests/dockerhub
         run: |
           docker buildx imagetools create ${{ steps.tags.outputs.dockerhub_tags }} \
-            $(printf 'docker.io/${{ github.actor }}/baseimage@sha256:%s ' *)
+            $(printf "docker.io/${DOCKERHUB_OWNER}/baseimage@sha256:%s " *)


### PR DESCRIPTION
Two changes to the build workflow.

**Image owner.** `github.actor` is the account that triggered the run, not the owner of the repository, so a push to `master` or a tag made by anyone else, a collaborator or a bot, builds image names in that account's namespace and attempts the ghcr.io and Docker Hub logins with that username against this repository's secrets. Pushes triggered by you hide the problem, because there both values are identical.

`github.repository_owner` keeps the canonical images exactly where they are, `ghcr.io/umputun/baseimage/*` and `umputun/baseimage`, and it preserves the part of the current behaviour that makes sense: whoever runs a fork still publishes into their own namespace. The Docker Hub half takes its owner from a `DOCKERHUB_OWNER` repository variable when one is set and falls back to the repository owner otherwise, so a fork whose Docker Hub account name differs from its GitHub owner can point it at the right account without editing the workflow. With no variable set, nothing changes here.

**Permissions and lint.** The workflow had no top-level `permissions` block, so the `merge` job ran with whatever the repository default grants. It now starts from `contents: read`, with `packages: write` added back on both jobs that push images. The `push` trigger listed `branches` and `tags` with no values, which behaves as match-all but fails `actionlint` as an empty string; `["**"]` states the same intent. Together with quoting `$GITHUB_OUTPUT` and marking the two manifest expansions that have to word-split, `actionlint` is now clean on the workflow.

Action version bumps are left to the open dependabot PR #49.